### PR TITLE
move the choices to simple_properties,can be gotten as a dict

### DIFF
--- a/webexteamssdk/models/cards/inputs.py
+++ b/webexteamssdk/models/cards/inputs.py
@@ -163,9 +163,9 @@ class Choices(AdaptiveCardComponent):
         self.spacing = spacing
 
         super().__init__(
-            serializable_properties=['choices'],
+            serializable_properties=[],
             simple_properties=[
                 'id', 'type', 'isMultiSelect', 'style', 'value', 'height',
-                'separator', 'spacing',
+                'separator', 'spacing','choices',
             ],
         )


### PR DESCRIPTION
We can run this code rightly with fixing this bugs of choices.

```
    choices_list= [
                {
                    "title": "Red",
                    "value": "Red"
                },
                {
                    "title": "Blue",
                    "value": "Blue"
                },
                {
                    "title": "Green",
                    "value": "Green"
                }
            ]
    data_type = Choices(choices=choices_list,id="choices",style="select")
    #dt=data_type.to_dict()
    #print(dt)
    utime =Date('updatetime')
    submit = Submit(title="Send Send!")
    card = AdaptiveCard(body=[greeting, first_name,data_type,age,utime], actions=[submit])