### PR TITLE
added export for WEBEX_TEAMS_ACCESS_TOKEN

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -60,7 +60,7 @@ It can be as simple as setting it in your CLI before running your script...
 
 .. code-block:: bash
 
-    $ WEBEX_TEAMS_ACCESS_TOKEN=your_access_token_here
+    $ export WEBEX_TEAMS_ACCESS_TOKEN=your_access_token_here
     $ python myscript.py
 
 ...or putting your credentials in a shell script that you ``source`` when your


### PR DESCRIPTION
The env variable needs to be exported, for python scripts to be able to access it.