### PR TITLE
Fixed broken links in docs

### DIFF
--- a/docs/user/cards.rst
+++ b/docs/user/cards.rst
@@ -43,11 +43,12 @@ client:
 
 
 Processing a card action
-=======================
+========================
+
 
 Adaptive card interactions are treated as "attachment actions". Once user interacts 
 with your card and submits an action, your app will receive a webhook from Webex. You 
-must `setup a webhook <api.rst#webhooks>`_ in advance with ``resource = "attachmentActions"`` 
+must :ref:`setup a webhook <webhooks>` in advance with ``resource = "attachmentActions"`` 
 and ``event = "created"``.
 
 Webhook payload will contain a JSON:
@@ -64,7 +65,7 @@ Webhook payload will contain a JSON:
     }
 
 Extract attachment action ID from ``['data']['id']`` and 
-use `attachment_actions.get() <api.rst#attachment_actions>`_ to get full information 
+use :ref:`attachment_actions.get() <attachment_actions>` to get full information 
 about user action and any submitted data.
 
 .. code-block:: python


### PR DESCRIPTION
This PR is in reference to #184 that was recently merged. The PR included broken links in the docs section that this PR fixes. 

Changes:

* Links to additional card resources now point to the correct anchors in the docs file.
* Also fixed a section underlining that was too short and thus triggered a warning whenever building the docs.