### PR TITLE
Add registerLink return attribute to webinars (meetings endpoint)

### DIFF
--- a/generator/models/meetings.yaml
+++ b/generator/models/meetings.yaml
@@ -206,6 +206,9 @@ list:
     - name: webLink
       description: Link to a meeting information page that launches the client
       type: basestring
+    - name: registerLink
+      description: Link to a page where attendees can register for the webinar. Only applies for webinars.
+      type: basestring
     - name: sipAddress
       description: SIP address for callback from a video system
       type: basestring

--- a/webexteamssdk/models/mixins/meetings.py
+++ b/webexteamssdk/models/mixins/meetings.py
@@ -127,6 +127,11 @@ class MeetingBasicPropertiesMixin(object):
         return self._json_data.get("webLink")
     
     @property
+    def registerLink(self):
+        """Link to a page where attendees can register for the webinar. Only applies for webinars."""
+        return self._json_data.get("registerLink")
+    
+    @property
     def sipAddress(self):
         """SIP address for callback from a video system"""
         return self._json_data.get("sipAddress")


### PR DESCRIPTION
The Meeting endpoint now returns the registerLink attribute. It is a link attendees use to register to a webinar. It is not yet documented in the API reference.