### PR TITLE
Message editing method change to update()

### DIFF
--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -355,6 +355,24 @@ def test_get_message_by_id(api, group_room_text_message):
     assert is_valid_message(message)
 
 
+def test_update_message_by_id(api, group_room_text_message):
+    message = api.messages.update(
+        group_room_text_message.id, 
+        roomId=group_room_text_message.roomId,
+        text=group_room_text_message.text+" updated!"
+    )
+    assert is_valid_message(message)
+    assert message.text.endswith(" updated!")
+
+    message = api.messages.edit(
+        group_room_text_message.id, 
+        roomId=group_room_text_message.roomId,
+        text=group_room_text_message.text+" edited!"
+    )
+    assert is_valid_message(message)
+    assert message.text.endswith(" edited!")
+
+
 def test_delete_message(api, group_room, send_group_room_message):
     text = create_string("Message")
     message = api.messages.create(group_room.id, text=text)

--- a/webexteamssdk/api/messages.py
+++ b/webexteamssdk/api/messages.py
@@ -339,11 +339,11 @@ class MessagesAPI(object):
         # API request
         self._session.delete(API_ENDPOINT + '/' + messageId)
 
-    def edit(self, messageId=None, roomId=None, text=None, markdown=None):
-        """Edit a message.
+    def update(self, messageId=None, roomId=None, text=None, markdown=None):
+        """Update (edit) a message.
 
         Args:
-            messageId(basestring): The ID of the message to be edit.
+            messageId(basestring): The ID of the message to be updated.
             roomId(basestring): The room ID.
             text(basestring): The message, in plain text. If `markdown` is
                 specified this parameter may be optionally used to provide
@@ -371,3 +371,6 @@ class MessagesAPI(object):
 
         # Return a message object created from the response JSON data
         return self._object_factory(OBJECT_TYPE, json_data)
+
+    # Add edit() as an alias to the update() method for backward compatibility
+    edit = update


### PR DESCRIPTION
All update CRUD methods in the SDK are named ```update()```, except for the ```messages``` endpoint . This fix changes the method name to ```update()``` to align with the SDK design. For backward compatibility, the ```edit()``` method is added as an alias.