### PR TITLE
refactor: GitHub Actions Workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,43 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    environment: chris-1xrn.wbx.ai
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install Dependencies
+        run: pip install -r requirements.txt
+      - name: Get Webex Token
+        id: webex_token
+        run: |
+          WEBEX_TEAMS_ACCESS_TOKEN=$(curl -s ${{ secrets.WEBEX_TOKEN_KEEPER_URL }} | jq -r .access_token)
+          echo "WEBEX_TEAMS_ACCESS_TOKEN=$WEBEX_TEAMS_ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$WEBEX_TEAMS_ACCESS_TOKEN"
+      - name: Build and Test
+        run: script/ci
+        env:
+          WEBEX_TEAMS_ACCESS_TOKEN: ${{ steps.webex_token.outputs.WEBEX_TEAMS_ACCESS_TOKEN }}
+          WEBEX_TEAMS_TEST_DOMAIN: ${{ vars.WEBEX_TEAMS_TEST_DOMAIN }}
+          WEBEX_TEAMS_TEST_ID_START: ${{ vars.WEBEX_TEAMS_TEST_ID_START }}
+          WEBEX_TEAMS_TEST_FILE_URL: ${{ vars.WEBEX_TEAMS_TEST_FILE_URL }}
+          WEBEX_TEAMS_GUEST_ISSUER_ID: ${{ secrets.WEBEX_TEAMS_GUEST_ISSUER_ID }}
+          WEBEX_TEAMS_GUEST_ISSUER_SECRET: ${{ secrets.WEBEX_TEAMS_GUEST_ISSUER_SECRET }}
+      - name: Upload Distribution Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: distribution-files
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,35 +3,27 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*"
-      - "v*.*.*"
+      - "v*"
 
 jobs:
+  build-and-test:
+    name: Build and Test
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+
   pypi:
-    name: Release to PyPI
+    needs: build-and-test
+    name: Publish to PyPI
     runs-on: ubuntu-latest
-    environment: pypi.org
+    environment: test.pypi.org
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Dependencies
-        run: pip install -r requirements.txt
-      - name: Get Webex Token
-        id: webex_token
-        run: |
-          WEBEX_TEAMS_ACCESS_TOKEN=$(curl -s ${{ secrets.WEBEX_TOKEN_KEEPER_URL }} | jq -r .access_token)
-          echo "WEBEX_TEAMS_ACCESS_TOKEN=$WEBEX_TEAMS_ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
-          echo "::add-mask::$WEBEX_TEAMS_ACCESS_TOKEN"
-      - name: Build and Test
-        run: script/ci
-        env:
-          WEBEX_TEAMS_ACCESS_TOKEN: ${{ steps.webex_token.outputs.WEBEX_TEAMS_ACCESS_TOKEN }}
-          WEBEX_TEAMS_TEST_DOMAIN: ${{ vars.WEBEX_TEAMS_TEST_DOMAIN }}
-          WEBEX_TEAMS_TEST_ID_START: ${{ vars.WEBEX_TEAMS_TEST_ID_START }}
-          WEBEX_TEAMS_TEST_FILE_URL: ${{ vars.WEBEX_TEAMS_TEST_FILE_URL }}
-          WEBEX_TEAMS_GUEST_ISSUER_ID: ${{ secrets.WEBEX_TEAMS_GUEST_ISSUER_ID }}
-          WEBEX_TEAMS_GUEST_ISSUER_SECRET: ${{ secrets.WEBEX_TEAMS_GUEST_ISSUER_SECRET }}
+      - name: Download Distribution Files
+        uses: actions/download-artifact@v4
+        with:
+          name: distribution-files
+          path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
- Separate the build and test workflow from the release workflow
- Reuse the build and test workflow in the release workflow
- Use GitHub Actions environment to store the environment variables and secrets for the test sandbox environment
- Run live API tests weekly at 8:00 AM EST
- Allow the build-and-test workflow to be triggered manually