### PR TITLE
chore(docs): use rtd theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
       id-token: write
     environment:
       name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       POETRY_VIRTUALENVS_CREATE: false
     steps:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 
 import webexpythonsdk
+import sphinx_rtd_theme
 
 
 project = "webexpythonsdk"
@@ -52,13 +53,9 @@ todo_include_todos = True
 # a list of builtin themes.
 #
 # html_theme = 'alabaster'
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-if not on_rtd:
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
In order to resolve #237, this fixes the ability to deploy the docs to github pages via the github action.

I tested this workflow on my branch and the output is here: https://adamweeks.github.io/WebexPythonSDK/
https://github.com/adamweeks/WebexPythonSDK/actions/runs/10291284373