### PR TITLE
Add additional properties to Room and fix missing arguments in rooms API

### DIFF
--- a/src/webexpythonsdk/api/rooms.py
+++ b/src/webexpythonsdk/api/rooms.py
@@ -176,6 +176,11 @@ class RoomsAPI(object):
             request_parameters,
             title=title,
             teamId=teamId,
+            classificationId=classificationId,
+            isLocked=isLocked,
+            isPublic=isPublic,
+            description=description,
+            isAnnouncementOnly=isAnnouncementOnly,
         )
 
         # API request

--- a/src/webexpythonsdk/models/mixins/room.py
+++ b/src/webexpythonsdk/models/mixins/room.py
@@ -85,3 +85,45 @@ class RoomBasicPropertiesMixin(object):
     def ownerId(self):
         """The ID of the organization which owns this room."""
         return self._json_data.get("ownerId")
+
+    @property
+    def classificationId(self):
+        """The ID of the current classification."""
+        return self._json_data.get("ownerId")
+
+    @property
+    def isAnnouncementOnly(self):
+        """Indicates when a space is in Announcement Mode (only moderators can post)."""
+        return self._json_data.get("ownerId")
+
+    @property
+    def isReadOnly(self):
+        """Room is read-only.
+
+        A compliance officer can set a direct room as read-only, which will disallow any
+        new information exchanges in this space, while maintaining historical data.
+        """
+        return self._json_data.get("ownerId")
+
+    @property
+    def isPublic(self):
+        """Room is public.
+
+        The room is public and therefore discoverable within the org. Anyone can find
+        and join the room.
+        """
+        return self._json_data.get("ownerId")
+
+    @property
+    def madePublic(self):
+        """Date and time when the room was made public."""
+        made_public = self._json_data.get("created")
+        if made_public:
+            return WebexDateTime.strptime(made_public)
+        else:
+            return None
+
+    @property
+    def description(self):
+        """The description of the room."""
+        return self._json_data.get("ownerId")


### PR DESCRIPTION
This pull request includes two commits;  these changes enhance the functionality and completeness of the Room class and ensure that the rooms API works correctly.

The first commit adds additional properties to the Room class, including `classificationId`, `isAnnouncementOnly`, `isReadOnly`, `isPublic`, `madePublic`, and `description`.

The second commit fixes missing arguments in the rooms API by adding the create room args to the `post_data`.

Fixes #244