### PR TITLE
Remove backslash from f-string (Patch for Issue: #247)

### DIFF
--- a/src/webexpythonsdk/models/cards/__init__.py
+++ b/src/webexpythonsdk/models/cards/__init__.py
@@ -22,11 +22,9 @@ SOFTWARE.
 """
 
 from webexpythonsdk.models.cards.adaptive_card_component import (
-    AdaptiveCardComponent
+    AdaptiveCardComponent,
 )
-from webexpythonsdk.models.cards.cards import (
-    AdaptiveCard
-)
+from webexpythonsdk.models.cards.cards import AdaptiveCard
 from webexpythonsdk.models.cards.card_elements import (
     TextBlock,
     Image,

--- a/src/webexpythonsdk/models/cards/actions.py
+++ b/src/webexpythonsdk/models/cards/actions.py
@@ -153,9 +153,7 @@ class OpenUrl(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -164,9 +162,7 @@ class OpenUrl(AdaptiveCardComponent):
                 "iconUrl",
                 "id",
                 "style",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "requires",
             ],
         )
@@ -246,7 +242,7 @@ class Submit(AdaptiveCardComponent):
                 str,
                 object,
             ),
-            optional=True
+            optional=True,
         )
 
         validate_input(
@@ -315,9 +311,7 @@ class Submit(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -327,9 +321,7 @@ class Submit(AdaptiveCardComponent):
                 "iconUrl",
                 "id",
                 "style",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "requires",
             ],
         )
@@ -461,9 +453,7 @@ class ShowCard(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "card",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -471,9 +461,7 @@ class ShowCard(AdaptiveCardComponent):
                 "iconUrl",
                 "id",
                 "style",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "requires",
             ],
         )
@@ -608,9 +596,7 @@ class ToggleVisibility(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "targetElements",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -618,9 +604,7 @@ class ToggleVisibility(AdaptiveCardComponent):
                 "iconUrl",
                 "id",
                 "style",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "requires",
             ],
         )

--- a/src/webexpythonsdk/models/cards/card_elements.py
+++ b/src/webexpythonsdk/models/cards/card_elements.py
@@ -267,9 +267,7 @@ class TextBlock(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -282,9 +280,7 @@ class TextBlock(AdaptiveCardComponent):
                 "size",
                 "weight",
                 "wrap",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -531,9 +527,7 @@ class Image(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "selectAction",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -545,9 +539,7 @@ class Image(AdaptiveCardComponent):
                 "size",
                 "style",
                 "width",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "separator",
                 "spacing",
                 "id",
@@ -726,17 +718,13 @@ class Media(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "sources",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
                 "poster",
                 "altText",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -954,16 +942,12 @@ class RichTextBlock(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "inlines",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
                 "horizontalAlignment",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",

--- a/src/webexpythonsdk/models/cards/cards.py
+++ b/src/webexpythonsdk/models/cards/cards.py
@@ -219,7 +219,8 @@ class AdaptiveCard(AdaptiveCardComponent):
                 "actions",
                 "selectAction",
                 *(
-                    ["backgroundImage"] if hasattr(backgroundImage, "to_dict")
+                    ["backgroundImage"]
+                    if hasattr(backgroundImage, "to_dict")
                     else []
                 ),
             ],
@@ -228,7 +229,8 @@ class AdaptiveCard(AdaptiveCardComponent):
                 "version",
                 "fallbackText",
                 *(
-                    [] if hasattr(backgroundImage, "to_dict")
+                    []
+                    if hasattr(backgroundImage, "to_dict")
                     else ["backgroundImage"]
                 ),
                 "minHeight",

--- a/src/webexpythonsdk/models/cards/containers.py
+++ b/src/webexpythonsdk/models/cards/containers.py
@@ -186,15 +186,11 @@ class ActionSet(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "actions",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -455,12 +451,11 @@ class Container(AdaptiveCardComponent):
                 "items",
                 "selectAction",
                 *(
-                    ["backgroundImage"] if hasattr(backgroundImage, "to_dict")
+                    ["backgroundImage"]
+                    if hasattr(backgroundImage, "to_dict")
                     else []
                 ),
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -468,13 +463,12 @@ class Container(AdaptiveCardComponent):
                 "verticalContentAlignment",
                 "bleed",
                 *(
-                    [] if hasattr(backgroundImage, "to_dict")
+                    []
+                    if hasattr(backgroundImage, "to_dict")
                     else ["backgroundImage"]
                 ),
                 "minHeight",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -504,7 +498,7 @@ class ColumnSet(AdaptiveCardComponent):
         minHeight: str = None,
         horizontalAlignment: OPTIONS.HorizontalAlignment = None,
         fallback: object = None,
-        height: OPTIONS.BlockElementHeight=None,
+        height: OPTIONS.BlockElementHeight = None,
         separator: bool = None,
         spacing: OPTIONS.Spacing = None,
         id: str = None,
@@ -698,9 +692,7 @@ class ColumnSet(AdaptiveCardComponent):
             serializable_properties=[
                 "columns",
                 "selectAction",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -708,9 +700,7 @@ class ColumnSet(AdaptiveCardComponent):
                 "bleed",
                 "minHeight",
                 "horizontalAlignment",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -959,24 +949,22 @@ class Column(AdaptiveCardComponent):
             serializable_properties=[
                 "items",
                 *(
-                    ["backgroundImage"] if hasattr(backgroundImage, "to_dict")
+                    ["backgroundImage"]
+                    if hasattr(backgroundImage, "to_dict")
                     else []
                 ),
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
                 "selectAction",
             ],
             simple_properties=[
                 "type",
                 *(
-                    [] if hasattr(backgroundImage, "to_dict")
+                    []
+                    if hasattr(backgroundImage, "to_dict")
                     else ["backgroundImage"]
                 ),
                 "bleed",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "minHeight",
                 "separator",
                 "spacing",
@@ -1135,15 +1123,11 @@ class FactSet(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "facts",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "id",
@@ -1215,7 +1199,7 @@ class ImageSet(AdaptiveCardComponent):
         height: OPTIONS.BlockElementHeight = None,
         separator: bool = None,
         spacing: OPTIONS.Spacing = None,
-        id: str  = None,
+        id: str = None,
         isVisible: bool = True,
         requires: dict[str, str] = None,
     ):
@@ -1357,16 +1341,12 @@ class ImageSet(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "images",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
                 "imageSize",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",

--- a/src/webexpythonsdk/models/cards/inputs.py
+++ b/src/webexpythonsdk/models/cards/inputs.py
@@ -277,9 +277,7 @@ class Text(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "inlineAction",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -293,9 +291,7 @@ class Text(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -506,9 +502,7 @@ class Number(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -520,9 +514,7 @@ class Number(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -733,9 +725,7 @@ class Date(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -747,9 +737,7 @@ class Date(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -777,7 +765,7 @@ class Time(AdaptiveCardComponent):
         value: str = None,
         errorMessage: str = None,
         isRequired: bool = None,
-        label:  str = None,
+        label: str = None,
         fallback: object = None,
         height: OPTIONS.BlockElementHeight = None,
         separator: bool = None,
@@ -960,9 +948,7 @@ class Time(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "id",
@@ -974,9 +960,7 @@ class Time(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -1196,9 +1180,7 @@ class Toggle(AdaptiveCardComponent):
 
         super().__init__(
             serializable_properties=[
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -1211,9 +1193,7 @@ class Toggle(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",
@@ -1450,9 +1430,7 @@ class ChoiceSet(AdaptiveCardComponent):
         super().__init__(
             serializable_properties=[
                 "choices",
-                *(
-                    ["fallback"] if hasattr(fallback, "to_dict") else []
-                ),
+                *(["fallback"] if hasattr(fallback, "to_dict") else []),
             ],
             simple_properties=[
                 "type",
@@ -1465,9 +1443,7 @@ class ChoiceSet(AdaptiveCardComponent):
                 "errorMessage",
                 "isRequired",
                 "label",
-                *(
-                    [] if hasattr(fallback, "to_dict") else ["fallback"]
-                ),
+                *([] if hasattr(fallback, "to_dict") else ["fallback"]),
                 "height",
                 "separator",
                 "spacing",

--- a/src/webexpythonsdk/models/cards/utils.py
+++ b/src/webexpythonsdk/models/cards/utils.py
@@ -27,11 +27,11 @@ from urllib.parse import urlparse
 
 
 def check_type(
-        obj: object,
-        acceptable_types: Any,
-        optional: bool = False,
-        is_list: bool = False,
-        ):
+    obj: object,
+    acceptable_types: Any,
+    optional: bool = False,
+    is_list: bool = False,
+):
     """
     Object is an instance of one of the acceptable types or None.
 
@@ -60,7 +60,7 @@ def check_type(
                 "following types: "
                 f"{', '.join([repr(t.__name__) for t in acceptable_types])}"
                 f"{' or None' if optional else ''}; instead we received "
-                f"'{obj}' which is a '{repr(type(obj).__name__)}'."
+                f"{obj} which is a {repr(type(obj).__name__)}."
             )
             raise TypeError(error_message)
 
@@ -71,7 +71,7 @@ def check_type(
                     "following types: "
                     f"{', '.join(repr(t.__name__) for t in acceptable_types)}"
                     f"{' or None' if optional else ''}; instead we "
-                    f"received '{o}' which is a '{repr(type(o).__name__)}'."
+                    f"received {o} which is a {repr(type(o).__name__)}."
                 )
                 raise TypeError(error_message)
         return
@@ -83,17 +83,17 @@ def check_type(
             "We were expecting to receive an instance of one of the following "
             f"types: {', '.join(repr(t.__name__) for t in acceptable_types)}"
             f"{' or None' if optional else ''}; but instead we received "
-            f"'{obj}' which is a '{repr(type(obj).__name__)}'."
+            f"{obj} which is a {repr(type(obj).__name__)}."
         )
 
         raise TypeError(error_message)
 
 
 def validate_input(
-        input_value: Any,
-        allowed_values: Any,
-        optional: bool = False,
-        ):
+    input_value: Any,
+    allowed_values: Any,
+    optional: bool = False,
+):
     """
     Validate if the input value is in the tuple of allowed values.
 
@@ -117,9 +117,7 @@ def validate_input(
         expected_values = tuple(
             f"{item.__class__.__name__}.{item.name}" for item in allowed_values
         )
-        allowed_values = tuple(
-            item.value for item in allowed_values
-        )
+        allowed_values = tuple(item.value for item in allowed_values)
 
     # Convert a single string to a tuple of one string
     if isinstance(allowed_values, str):
@@ -148,11 +146,11 @@ def validate_input(
 
 
 def validate_dict_str(
-        input_value: Any,
-        key_type: Type,
-        value_type: Type,
-        optional: bool = False,
-        ):
+    input_value: Any,
+    key_type: Type,
+    value_type: Type,
+    optional: bool = False,
+):
     """
     Validate that the input is a dictionary and that all keys and values in the
     dictionary are of the specified types.
@@ -201,9 +199,9 @@ class URIException(Exception):
 
 
 def validate_uri(
-        uri: Any,
-        optional=False,
-        ):
+    uri: Any,
+    optional=False,
+):
     """
     Validate the given URI and raise an exception if it is invalid.
 

--- a/src/webexpythonsdk/models/cards/utils.py
+++ b/src/webexpythonsdk/models/cards/utils.py
@@ -59,8 +59,8 @@ def check_type(
                 "We were expecting to receive a list of objects of the "
                 "following types: "
                 f"{', '.join([repr(t.__name__) for t in acceptable_types])}"
-                f"{' or \'None\'' if optional else ''}; instead we received "
-                f"{obj} which is a {repr(type(obj).__name__)}."
+                f"{' or None' if optional else ''}; instead we received "
+                f"'{obj}' which is a '{repr(type(obj).__name__)}'."
             )
             raise TypeError(error_message)
 
@@ -70,8 +70,8 @@ def check_type(
                     "We were expecting to receive an object of one of the "
                     "following types: "
                     f"{', '.join(repr(t.__name__) for t in acceptable_types)}"
-                    f"{' or \'None\'' if optional else ''}; instead we "
-                    f"received {o} which is a {repr(type(o).__name__)}."
+                    f"{' or None' if optional else ''}; instead we "
+                    f"received '{o}' which is a '{repr(type(o).__name__)}'."
                 )
                 raise TypeError(error_message)
         return
@@ -82,8 +82,8 @@ def check_type(
         error_message = (
             "We were expecting to receive an instance of one of the following "
             f"types: {', '.join(repr(t.__name__) for t in acceptable_types)}"
-            f"{' or \'None\'' if optional else ''}; but instead we received "
-            f"{obj} which is a {repr(type(obj).__name__)}."
+            f"{' or None' if optional else ''}; but instead we received "
+            f"'{obj}' which is a '{repr(type(obj).__name__)}'."
         )
 
         raise TypeError(error_message)
@@ -141,7 +141,7 @@ def validate_input(
     if value_to_check not in allowed_values:
         raise ValueError(
             f"Invalid value: '{input_value}'. "
-            f"Must be one of {expected_values}."
+            f"Must be one of '{expected_values}'."
         )
 
     return

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -364,17 +364,20 @@ def test_get_message_by_id(api, group_room_text_message):
     message = api.messages.get(group_room_text_message.id)
     assert is_valid_message(message)
 
+
 def test_delete_message(api, group_room, send_group_room_message):
     text = create_string("Message")
     message = api.messages.create(group_room.id, text=text)
     assert is_valid_message(message)
     api.messages.delete(message.id)
 
+
 def test_edit_message(api, group_room):
     text = create_string("Edit this Message")
     message = api.messages.create(group_room.id, text=text)
     text = create_string("Message Edited")
     assert text == api.messages.edit(message.id, group_room.id, text).text
+
 
 def test_update_message(api, group_room):
     text = create_string("Update this Message")


### PR DESCRIPTION
Remove backslash from f-string to maintain backward compatibility with Python 3.10 and 3.11 versions.

Also, corrected little (very minor non-impacting) cosmetic issues.

Patch for Issue: #247 