### PR TITLE
refactor(contributing): fixed github action failure

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -79,6 +79,7 @@ Contributing Code
 8. If you running the test suite locally, ensure your code passes all of the default tests.  Use the ``test`` target and ensure all tests execute successfully.
 
    .. code-block:: bash
+      
       # see below for more information on running the test suite locally
       make tests
 


### PR DESCRIPTION

**Root Cause**: Missing blank line after `code-block` directive caused RST to interpret content as arguments.

**Fix**: Added blank line to separate directive from content:

```diff
.. code-block:: bash
+   
   # see below for more information on running the test suite locally
   make tests
