### PR TITLE
docs: warn that card actions require an explicit attachmentActions webhook

### DIFF
--- a/src/webexpythonsdk/api/messages.py
+++ b/src/webexpythonsdk/api/messages.py
@@ -233,6 +233,16 @@ class MessagesAPI(object):
                 be posted into the room. Only one file is allowed per message.
             attachments(list): Content attachments to attach to the message.
                 See the Cards Guide for more information.
+
+                .. warning::
+                    Sending a card does **not** automatically enable your
+                    application to receive webhook notifications when a user
+                    interacts with it (e.g. submits a form). To receive those
+                    events you must explicitly create a webhook with
+                    ``resource="attachmentActions"`` and ``event="created"``
+                    via ``api.webhooks.create()``. Without that webhook, card
+                    actions are silently discarded from your application's
+                    perspective.
             parentId(str): The parent message to reply to. This will
                 start or reply to a thread.
             **request_parameters: Additional request parameters (provides

--- a/src/webexpythonsdk/models/cards/cards.py
+++ b/src/webexpythonsdk/models/cards/cards.py
@@ -46,6 +46,13 @@ class AdaptiveCard(AdaptiveCardComponent):
 
     **_Note:_** Webex currently supports version 1.3 of adaptive cards and
     thus only features from that release are supported in this abstraction.
+
+    **Webhook requirement for card actions:** Posting a card does *not*
+    automatically deliver user interactions (button clicks, form submits) to
+    your application. You must create a dedicated webhook with
+    ``resource="attachmentActions"`` and ``event="created"`` via
+    ``api.webhooks.create()`` to receive those events. Without that webhook,
+    card actions are invisible to your application.
     """
 
     type = "AdaptiveCard"


### PR DESCRIPTION
Without a webhook registered for resource=attachmentActions / event=created,
user interactions with posted cards (form submits, button clicks) are never
delivered to the application. Added a warning to MessagesAPI.create() and
AdaptiveCard so callers are informed at the point where cards are defined and
sent.

https://claude.ai/code/session_01GKKbMs8PKXo8m28TzQzYBD